### PR TITLE
Switch to FetchWithContext

### DIFF
--- a/pkg/cmd/fetcher.go
+++ b/pkg/cmd/fetcher.go
@@ -29,16 +29,16 @@ type ProxyArchiveFetcher struct {
 	maxUntarSize int
 }
 
-// Fetch implements the ArchiveFetcher implementation, but uses the Kube service
+// FetchWithContext implements the ArchiveFetcher implementation, but uses the Kube service
 // proxy mechanism to get the archive.
-func (p *ProxyArchiveFetcher) Fetch(archiveURL, checksum, dir string) error {
+func (p *ProxyArchiveFetcher) FetchWithContext(ctx context.Context, archiveURL, checksum, dir string) error {
 	parsed, err := parseArtifactURL(archiveURL)
 	if err != nil {
 		return err
 	}
 
 	responseWrapper := p.Client.Services(parsed.namespace).ProxyGet(parsed.scheme, parsed.name, parsed.port, parsed.path, nil)
-	b, err := responseWrapper.DoRaw(context.Background())
+	b, err := responseWrapper.DoRaw(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/local_client.go
+++ b/pkg/cmd/local_client.go
@@ -69,7 +69,7 @@ type localFetcher struct {
 	logger logr.Logger
 }
 
-func (l localFetcher) Fetch(archiveURL, checksum, dir string) error {
+func (l localFetcher) FetchWithContext(_ context.Context, archiveURL, checksum, dir string) error {
 	parsed, err := url.Parse(archiveURL)
 	if err != nil {
 		return err

--- a/pkg/parser/repository_parser.go
+++ b/pkg/parser/repository_parser.go
@@ -17,7 +17,7 @@ import (
 // ArchiveFetcher implementations should get the URL, validate the contents
 // against the checksum and leave the unpacked version in the dir.
 type ArchiveFetcher interface {
-	Fetch(archiveURL, checksum, dir string) error
+	FetchWithContext(ctx context.Context, archiveURL, checksum, dir string) error
 }
 
 // RepositoryParser fetches archives from a Repository and parses the
@@ -44,7 +44,7 @@ func (p *RepositoryParser) GenerateFromFiles(ctx context.Context, archiveURL, ch
 		}
 	}()
 
-	if err := p.fetcher.Fetch(archiveURL, checksum, tempDir); err != nil {
+	if err := p.fetcher.FetchWithContext(ctx, archiveURL, checksum, tempDir); err != nil {
 		return nil, fmt.Errorf("failed to get archive URL %s: %w", archiveURL, err)
 	}
 
@@ -82,7 +82,7 @@ func (p *RepositoryParser) GenerateFromDirectories(ctx context.Context, archiveU
 		}
 	}()
 
-	if err := p.fetcher.Fetch(archiveURL, checksum, tempDir); err != nil {
+	if err := p.fetcher.FetchWithContext(ctx, archiveURL, checksum, tempDir); err != nil {
 		return nil, fmt.Errorf("failed to get archive URL %s: %w", archiveURL, err)
 	}
 


### PR DESCRIPTION
**What changed?**

This updates the calls to the fetcher to use the newer FetchWithContext method.

- [ ] Has [Docs](https://github.com/weaveworks/gitopssets-controller/tree/main/docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps.
- [ ] Has Tests included if any functionality added or changed.
- [ ] Has an [Example](https://github.com/weaveworks/gitopssets-controller/tree/main/examples) if the change requires configuration to use.
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release.

For new Generators the above notes apply, with the following additional items:

- [ ] The Generator has been added to the Matrix generator's `GitOpsSetNestedGenerator`, this should be done by default unless there's some reason it doesn't work.
- [ ] The Generator has been added to the list of configurable [Generators](https://github.com/weaveworks/gitopssets-controller/blob/main/pkg/setup/generators.go), if you do not, the generator **cannot** be enabled!
- [ ] If the Generator depends on Kubernetes resources, a Watch has been added to track changes to the resources in the controller.

# Release Notes

```release-note
NONE
```
